### PR TITLE
Fix additional ``zestiamte`` typos

### DIFF
--- a/tests/test_valuation.py
+++ b/tests/test_valuation.py
@@ -1,4 +1,6 @@
 import unittest
+import warnings
+
 import xmltodict
 from zillow import Place
 
@@ -16,7 +18,7 @@ class TestGetSearchResult(unittest.TestCase):
         place.set_data(data.get('SearchResults:searchresults', None)['response']['results']['result'])
 
         self.assertEqual("2100641621", place.zpid)
-        self.assertEqual(1723665, place.zestiamte.amount)
+        self.assertEqual(1723665, place.zestimate.amount)
 
     def test_zestimate(self):
         RAW_XML = ""
@@ -29,7 +31,31 @@ class TestGetSearchResult(unittest.TestCase):
         place.set_data(data.get('Zestimate:zestimate', None)['response'])
 
         self.assertEqual("2100641621", place.zpid)
-        self.assertEqual(1723665, place.zestiamte.amount)
+        self.assertEqual(1723665, place.zestimate.amount)
+
+    def test_zestiamte(self):
+        """Test that the backward-compatible ``zestiamte`` works.
+
+        This property should correctly return the ``zestimate``
+        attribute and raise a DeprecationWarning about the changing
+        name.
+
+        """
+        warnings.simplefilter('always', DeprecationWarning)
+
+        with open('./testdata/get_zestimate.xml', 'r') as f:
+            RAW_XML = ''.join(f.readlines())
+
+        data = xmltodict.parse(RAW_XML)
+
+        place = Place()
+        place.set_data(data.get('Zestimate:zestimate', None)['response'])
+
+        self.assertEqual(place.zestiamte, place.zestimate)
+
+        with warnings.catch_warnings(record=True) as warning:
+            place.zestiamte
+            assert issubclass(warning[0].category, DeprecationWarning)
 
     def test_getcomps_principal(self):
         RAW_XML = ""

--- a/zillow/place.py
+++ b/zillow/place.py
@@ -1,4 +1,6 @@
 from abc import abstractmethod
+import warnings
+
 
 class SourceData(classmethod):
 
@@ -174,6 +176,17 @@ class Place(SourceData):
         self.extended_data = ExtendedData()
         self.has_extended_data = has_extended_data
 
+    @property
+    def zestiamte(self):
+        """Backward-compatible typo property to prevent breaking changes."""
+        warnings.warn(
+            'The ``zestiamte`` attribute has been renamed to '
+            '``zestimate`` and will be removed in a future release.',
+            DeprecationWarning,
+        )
+        return self.zestimate
+
+
     def set_data(self, source_data):
         """
         :source_data": Data from data.get('SearchResults:searchresults', None)['response']['results']['result']
@@ -185,7 +198,7 @@ class Place(SourceData):
         self.similarity_score = source_data.get('@score', None)
         self.links.set_data(source_data['links'])
         self.full_address.set_data(source_data['address'])
-        self.zestiamte.set_data(source_data['zestimate'])
+        self.zestimate.set_data(source_data['zestimate'])
         self.local_realestate.set_data(source_data['localRealEstate'])
         if self.has_extended_data:
             self.extended_data.set_data(source_data)
@@ -201,7 +214,3 @@ class Place(SourceData):
             'extended_data': self.extended_data.get_dict()
         }
         return data
-
-
-
-


### PR DESCRIPTION
- Fix typos in tests and ``set_data`` method
- Add a new ``zestiamte`` property to make the spelling correction
  backward-compatible until a release with breaking changes can go out

This is related to the changes made in #15.