### PR TITLE
Test with tox and travis

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,0 +1,20 @@
+language: python
+
+matrix:
+  include:
+    - python: 3.6
+      env: TOX_ENV=py36
+    - python: 3.5
+      env: TOX_ENV=py35
+    - python: 3.4
+      env: TOX_ENV=py34
+    - python: 2.7
+      env: TOX_ENV=py27
+
+install: pip install tox
+
+script: tox -e $TOX_ENV
+
+branches:
+  only:
+    - master

--- a/setup.py
+++ b/setup.py
@@ -40,6 +40,8 @@ setup(
         'Programming Language :: Python :: 2',
         'Programming Language :: Python :: 2.7',
         'Programming Language :: Python :: 3',
+        'Programming Language :: Python :: 3.4',
         'Programming Language :: Python :: 3.5',
+        'Programming Language :: Python :: 3.6',
     ],
 )

--- a/tox.ini
+++ b/tox.ini
@@ -1,0 +1,10 @@
+[tox]
+envlist = py{36,35,34,27}
+
+[testenv]
+deps =
+    coverage
+    nose
+
+commands =
+    nosetests --with-coverage --cover-package=zillow --cover-html


### PR DESCRIPTION
- Use tox to run tests for multiple Python versions
- Enable automated testing via Travis-CI
- Update setup.py to reflect all supported Python versions